### PR TITLE
Unexpectedly missing profile when user changes

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,7 +73,6 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
-    @robot.logger.info "user changed: #{Util.inspect(user)}"
     newUser =
       name: user.name
       real_name: user.real_name
@@ -84,6 +83,7 @@ class SlackBot extends Adapter
       # so, don't bother storing it
       continue if value instanceof SlackClient
       newUser.slack[key] = value
+    @robot.logger.info "user changed: #{Util.inspect(newUser)}"
 
     if user.id of @robot.brain.data.users
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,6 +73,7 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
+    @robot.logger.info "user changed: #{Util.inspect(user)}
     newUser =
       name: user.name
       real_name: user.real_name
@@ -85,6 +86,7 @@ class SlackBot extends Adapter
       newUser.slack[key] = value
 
     if user.id of @robot.brain.data.users
+
       for key, value of @robot.brain.data.users[user.id]
         unless key of newUser
           newUser[key] = value

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -76,7 +76,7 @@ class SlackBot extends Adapter
     newUser =
       name: user.name
       real_name: user.real_name
-      email_address: user.profile.email
+      email_address: user.profile?.email
       slack: {}
     for key, value of user
       # user contains an of the SlackClient, which and contains references to the all the data types (users, channels) plus things like the token, s

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,6 +73,7 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
+    return unless user?.id?
     newUser =
       name: user.name
       real_name: user.real_name

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -84,7 +84,6 @@ class SlackBot extends Adapter
       # so, don't bother storing it
       continue if value instanceof SlackClient
       newUser.slack[key] = value
-    @robot.logger.info "user changed: #{Util.inspect(newUser)}"
 
     if user.id of @robot.brain.data.users
 

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -73,7 +73,7 @@ class SlackBot extends Adapter
       if id is user.name then delete @robot.brain.data.users[user.id]
 
   userChange: (user) =>
-    @robot.logger.info "user changed: #{Util.inspect(user)}
+    @robot.logger.info "user changed: #{Util.inspect(user)}"
     newUser =
       name: user.name
       real_name: user.real_name


### PR DESCRIPTION
We found hubot not responding one day, and there was an error like:

```
TypeError: Cannot read property 'email' of undefined
  at SlackBot.userChange (node_modules/hubot-slack/src/slack.coffee:79:7, <js>:113:36)
  at SlackBot.__bind [as userChange] (node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at SlackBot.loggedIn (node_modules/hubot-slack/src/slack.coffee:64:7, <js>:83:28)
  at Client.__bind (node_modules/hubot-slack/src/slack.coffee:1:1, <js>:3:61)
  at Client.EventEmitter.emit (events.js:96:17)
  at Client._onLogin (node_modules/hubot-slack/node_modules/slack-client/src/client.js:100:14)
  at __bind (node_modules/hubot-slack/node_modules/slack-client/src/client.js:2:59)
  at IncomingMessage.Client._apiCall.req.on.callback.ok (node_modules/hubot-slack/node_modules/slack-client/src/client.js:670:22)
```

The profile was nil in this case. This PR uses logs the user for debugging and uses the existential operator to check for a profile to prevent a crash (maybe). This is against our master branch which has come changes, so I'll have to do a separate PR to get it fixed upstream once I've confirmed it.