### PR TITLE
Always send a fallback with attachment messages

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -213,7 +213,7 @@ class SlackBot extends Adapter
         {image_url: msg, fallback: msg}
       else
         @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
-        {text: msg, mrkdwn_in: ['text']}
+        {text: msg, mrkdwn_in: ['text'], fallback: msg}
 
       @customMessage channel: envelope.room, attachments: attachment
 


### PR DESCRIPTION
This is targeted at our `master` branch so we can start using it right away.