### PR TITLE
Don't make image attachments out of files.slack.com

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -217,6 +217,8 @@ class SlackBot extends Adapter
 
         msg = msg.substring(0, SlackBot.MAX_MESSAGE_LENGTH)
 
+      # Bots cannot display images from files.slack.com in images, as all
+      # images will be accessed anonymously.
       attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/) and !msg.match(/files.slack.com/)
         @robot.logger.debug "Sending to #{envelope.room} as image: #{msg}"
         {image_url: msg, fallback: msg}

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -219,7 +219,7 @@ class SlackBot extends Adapter
 
       # Bots cannot display images from files.slack.com in images, as all
       # images will be accessed anonymously.
-      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/) and !msg.match(/files.slack.com/)
+      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/) and !msg.match(/https:\/\/files\.slack\.com/)
         @robot.logger.debug "Sending to #{envelope.room} as image: #{msg}"
         {image_url: msg, fallback: msg}
       else

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -217,7 +217,7 @@ class SlackBot extends Adapter
 
         msg = msg.substring(0, SlackBot.MAX_MESSAGE_LENGTH)
 
-      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/)
+      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/) and !msg.match(/files.slack.com/)
         @robot.logger.debug "Sending to #{envelope.room} as image: #{msg}"
         {image_url: msg, fallback: msg}
       else


### PR DESCRIPTION
Slack support confirms that image attachments referencing `files.slack.com` do not have permission to unfurl them.