### PR TITLE
Add more file extensions

### DIFF
--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -219,7 +219,7 @@ class SlackBot extends Adapter
 
       # Bots cannot display images from files.slack.com in images, as all
       # images will be accessed anonymously.
-      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|png|gif)$/) and !msg.match(/https:\/\/files\.slack\.com/)
+      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|jpe|jpeg|png|gif|bmp|dib)$/) and !msg.match(/https:\/\/files\.slack\.com/)
         @robot.logger.debug "Sending to #{envelope.room} as image: #{msg}"
         {image_url: msg, fallback: msg}
       else

--- a/src/slack.coffee
+++ b/src/slack.coffee
@@ -219,7 +219,7 @@ class SlackBot extends Adapter
 
       # Bots cannot display images from files.slack.com in images, as all
       # images will be accessed anonymously.
-      attachment = if msg.match(/^https?:\/\/\S+(?:jpg|jpe|jpeg|png|gif|bmp|dib)$/) and !msg.match(/https:\/\/files\.slack\.com/)
+      attachment = if msg.match(/^https?:\/\/\S+\.(?:jpg|jpe|jpeg|png|gif|bmp|dib)/) and !msg.match(/https:\/\/files\.slack\.com/)
         @robot.logger.debug "Sending to #{envelope.room} as image: #{msg}"
         {image_url: msg, fallback: msg}
       else


### PR DESCRIPTION
Slack supports GIF, JPEG, PNG, BMP: https://api.slack.com/docs/attachments

Alternate file extensions for .jpg include .jpe and .jpeg: http://www.nationalarchives.gov.uk/PRONOM/Format/proFormatSearch.aspx?status=detailReport&id=667&strPageToDisplay=signatures
And .dib is an alternate extension for .bmp: http://www.nationalarchives.gov.uk/PRONOM/Format/proFormatSearch.aspx?status=detailReport&id=729&strPageToDisplay=signatures

refs github/hubot-classic#1881