### PR TITLE
Upgrade lodash to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@slack/client": "^3.4.0",
-    "lodash": "^3.10.1"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "coffee-coverage": "~1.0.1",


### PR DESCRIPTION
This is backported from this upstream commit: https://github.com/slackapi/hubot-slack/commit/5ac9a4c855fd081c5b003513c824695f1684bb58