### PR TITLE
Replace unmaintained @slack/client lib with current slack APIs

### DIFF
--- a/docs/_pages/basic_usage.md
+++ b/docs/_pages/basic_usage.md
@@ -117,14 +117,14 @@ You can access the [Slack Web API](https://api.slack.com/web_api) from your Hubo
 [Slack Developer Kit for Node.js](https://slackapi.github.io/node-slack-sdk/) package into your Hubot project:
 
 ```
-npm install --save @slack/client
+npm install --save @slack/web-api
 ```
 
 Next, modify your script to instatiate a `WebClient` object using the same token your Hubot used to connect.
 
 ```coffeescript
 # Import the Slack Developer Kit
-{WebClient} = require "@slack/client"
+{WebClient} = require "@slack/web-api"
 
 module.exports = (robot) ->
   web = new WebClient robot.adapter.options.token
@@ -136,7 +136,7 @@ Finally, anytime you'd like to call a Web API method, call it like a method on `
 
 ```coffeescript
 # Import the Slack Developer Kit
-{WebClient} = require "@slack/client"
+{WebClient} = require "@slack/web-api"
 
 module.exports = (robot) ->
   web = new WebClient robot.adapter.options.token
@@ -190,7 +190,7 @@ can both listen for these from other users, and send reactions of its own. Here 
 emoji reactions and add the same reaction back to the same message.
 
 ```coffeescript
-{WebClient} = require "@slack/client"
+{WebClient} = require "@slack/web-api"
 
 module.exports = (robot) ->
   web = new WebClient robot.adapter.options.token
@@ -250,7 +250,7 @@ set up that can update that variable based on an incoming message. Then a new li
 the current channel in the variable, no matter where the incoming message is received.
 
 ```coffeescript
-{WebClient} = require "@slack/client"
+{WebClient} = require "@slack/web-api"
 
 module.exports = (robot) ->
   web = new WebClient robot.adapter.options.token

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "url": "https://github.com/slackapi/hubot-slack/issues"
   },
   "dependencies": {
-    "@slack/client": "3.16.1-sec.2",
+    "@slack/rtm-api": "^6.0.0",
+    "@slack/web-api": "^6.4.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.10"
   },

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -1,4 +1,5 @@
-{RtmClient, WebClient, MemoryDataStore} = require '@slack/client'
+{RTMClient} = require "@slack/rtm-api"
+{WebClient} = require "@slack/web-api"
 SlackFormatter = require '../src/formatter'
 SlackClient = require '../src/client'
 should = require 'should'
@@ -6,12 +7,12 @@ _ = require 'lodash'
 
 describe 'Init', ->
   it 'Should initialize with an RTM client', ->
-    (@client.rtm instanceof RtmClient).should.equal true
-    @client.rtm._token.should.equal 'xoxb-faketoken'
+    (@client.rtm instanceof RTMClient).should.equal true
+    @client.rtm.webClient.token.should.equal 'xoxb-faketoken'
 
   it 'Should initialize with a Web client', ->
     (@client.web instanceof WebClient).should.equal true
-    @client.web._token.should.equal 'xoxb-faketoken'
+    @client.web.token.should.equal 'xoxb-faketoken'
 
   it 'Should initialize with a SlackFormatter - DEPRECATED', ->
     (@client.format instanceof SlackFormatter).should.equal true

--- a/test/stubs.coffee
+++ b/test/stubs.coffee
@@ -18,13 +18,13 @@ beforeEach ->
   @stubs = {}
 
   @stubs._sendCount = 0
-  @stubs.send = (conversationId, text, opts) =>
-    @stubs._room = conversationId
+  @stubs.send = (opts) =>
+    @stubs._room = opts.channel
     @stubs._opts = opts
-    if (/^[UD@][\d\w]+/.test(conversationId)) or (conversationId is @stubs.DM.id)
-      @stubs._dmmsg = text
+    if (/^[UD@][\d\w]+/.test(opts.channel)) or (opts.channel is @stubs.DM.id)
+      @stubs._dmmsg = opts.text
     else
-      @stubs._msg = text
+      @stubs._msg = opts.text
     @stubs._sendCount = @stubs._sendCount + 1
 
   # These objects are of conversation shape: https://api.slack.com/types/conversation
@@ -159,9 +159,9 @@ beforeEach ->
           when @stubs.channel.id then @stubs.channel
           when @stubs.DM.id then @stubs.DM
   @stubs.chatMock =
-    postMessage: (conversationId, text, opts) =>
-      return Promise.reject(new Error("stub error")) if conversationId is @stubs.channelWillFailChatPost
-      @stubs.send(conversationId, text, opts)
+    postMessage: (opts) =>
+      return Promise.reject(new Error("stub error")) if opts.channel is @stubs.channelWillFailChatPost
+      @stubs.send(opts)
       Promise.resolve()
   @stubs.conversationsMock =
     setTopic: (id, topic) =>


### PR DESCRIPTION
This commit removes the unmaintained @slack/client library which
hasn't been updated for years and is suffering from a few critial
security vulnerabilities.

We are replacing @slack/client with the slack-recommended
@slack/web-api and @slack/rtm-api libraries, which receive
current support.

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).